### PR TITLE
fix: negate skip flag assignment to CreateGitHubRelease

### DIFF
--- a/module/tasks/release.properties.ps1
+++ b/module/tasks/release.properties.ps1
@@ -3,7 +3,7 @@
 # </copyright>
 
 # Synopsis: When true, a GitHub release will be created with the current version number
-$CreateGitHubRelease = [Convert]::ToBoolean((property ZF_GITHUB_SKIP_CREATE_RELEASE $false))
+$CreateGitHubRelease = -not [Convert]::ToBoolean((property ZF_GITHUB_SKIP_CREATE_RELEASE $false))
 
 # Synopsis: When true, a GitHub release will not be created. Used by the internal Pester tests.
 $GitHubReleaseDryRunMode = [Convert]::ToBoolean((property ZF_GITHUB_RELEASE_DRY_RUN_MODE $false))


### PR DESCRIPTION
## Summary
- Fixes #3: `ZF_GITHUB_SKIP_CREATE_RELEASE=true` was enabling releases instead of disabling them due to missing negation

## Changes
- `module/tasks/release.properties.ps1`: Added `-not` to invert the skip-flag value when assigning to `$CreateGitHubRelease`

## Test plan
- [ ] Verify default behaviour (env var unset): `$CreateGitHubRelease` is `$true` (releases created)
- [ ] Verify with `ZF_GITHUB_SKIP_CREATE_RELEASE=true`: `$CreateGitHubRelease` is `$false` (releases skipped)
- [ ] CI build passes

🤖 Generated with Claude Code